### PR TITLE
fix: avoid cleaning for scheduling uuid

### DIFF
--- a/memium/destination/ankiconnect/anki_converter.py
+++ b/memium/destination/ankiconnect/anki_converter.py
@@ -43,7 +43,9 @@ class AnkiPromptConverter:
             return DestinationPrompt(
                 QAWithoutDoc(
                     QAPromptImpl(
+                        # Add raw question here
                         question=note_info.fields["Question"].value,
+                        # Add raw answer here
                         answer=note_info.fields["Answer"].value,
                     ),
                     add_tags=note_info.tags,

--- a/memium/destination/ankiconnect/anki_prompt_qa.py
+++ b/memium/destination/ankiconnect/anki_prompt_qa.py
@@ -35,6 +35,8 @@ class AnkiPrompt:
             {"name": "Answer"},
             {"name": "Extra"},
             {"name": "UUID"},
+            {"name": "Question raw"},
+            {"name": "Answer raw"},
         ]
 
         QUESTION_STR = r"{{ Question }}"
@@ -65,9 +67,10 @@ class AnkiPrompt:
             }
         ]
 
+        field_names = [d["name"] for d in model_fields]
         return genanki.Model(
-            model_id=hash_str_to_int("Ankdown QA with UUID"),
-            name=("Ankdown QA with UUID"),
+            model_id=hash_str_to_int("-".join(field_names)),
+            name=(f"Ankdown QA with {field_names}"),
             fields=model_fields,
             templates=model_template,
             css=self.css,
@@ -96,6 +99,8 @@ class AnkiPrompt:
                 self._md_to_html(self.prompt.answer),
                 self._extra_field_content,
                 str(self.uuid),
+                self.prompt.question,
+                self.prompt.answer,
             ],
             tags=self.tags,
         )

--- a/memium/destination/ankiconnect/test_anki_prompt_qa.py
+++ b/memium/destination/ankiconnect/test_anki_prompt_qa.py
@@ -78,6 +78,5 @@ def test_formatting():
         opacity: 0.8;
 ">Obsidian</a></div>\
 """,
-            "3462918412",
-        ]
+            "3462918412", 'Q. This is a _question_?', 'DummyAnswer']
     )

--- a/memium/destination/test_destination_ankiconnect.py
+++ b/memium/destination/test_destination_ankiconnect.py
@@ -1,10 +1,13 @@
 from collections.abc import Mapping
+from pathlib import Path
 
 import pytest
 
 from ..source.prompts.prompt_qa import QAWithoutDoc
 from .ankiconnect.anki_converter import AnkiPromptConverter
 from .ankiconnect.ankiconnect_gateway import (
+    ANKICONNECT_URL,
+    AnkiConnectGateway,
     AnkiField,
     ImportPackage,
     SpieAnkiconnectGateway,
@@ -73,3 +76,19 @@ def test_ankiconnect_push_prompts():
         assert (
             len([c for c in gateway.executed_commands if isinstance(c, command[0])]) == command[1]
         )
+
+
+def test_getting_all_prompts(tmp_path: Path):
+    gateway = AnkiConnectGateway(
+        ankiconnect_url=ANKICONNECT_URL,
+        base_deck="Memium",
+        tmp_read_dir=tmp_path,
+        tmp_write_dir=tmp_path,
+        max_deletions_per_run=10,
+        max_wait_seconds=3600,
+    )
+    dest = AnkiConnectDestination(
+        gateway=gateway,
+        prompt_converter=AnkiPromptConverter(base_deck="FakeDeck", card_css="FakeCSS"),
+    )
+    dest.get_all_prompts()

--- a/memium/source/prompts/prompt_qa.py
+++ b/memium/source/prompts/prompt_qa.py
@@ -44,8 +44,10 @@ class QAPromptImpl(QAPromptProtocol):
 
     @property
     def scheduling_uid_str(self) -> str:
-        """Str used for generating the update_uid. Super helpful for debugging."""
-        return qa_scheduling_uid_str(self.question, self.answer)
+        """Str used for generating the update_uid. We clean this of formatting so that formatting changes do not change the uid.
+
+        This is required because Anki requires the formatted question and answer to be part of the note."""
+        return cleaned_qa_scheduling_uid_str(self.question, self.answer)
 
     @property
     def scheduling_uid(self) -> int:
@@ -148,12 +150,8 @@ class QAFromDoc(BasePrompt, PromptFromDoc):
         return obsidian_url(self.parent_doc.title, self.line_nr)
 
 
-def qa_scheduling_uid_str(question: str, answer: str) -> str:
+def cleaned_qa_scheduling_uid_str(question: str, answer: str) -> str:
     return f"{clean_str(question)}_{clean_str(answer)}"
-
-
-def qa_update_uid_str(question: str, answer: str, tags: Sequence[str]) -> str:
-    return f"{question}_{answer}_{tags}"
 
 
 QAPrompt = QAWithoutDoc | QAFromDoc

--- a/readme.md
+++ b/readme.md
@@ -101,10 +101,6 @@ inv validate_ci
 [github discussions]: https://github.com/MartinBernstorff/memium/discussions
 
 # Roadmap
-* p2: Is there a need for "QAWithoutDoc"? It is because the 
-  * Seems it's being used inside `DestinationPrompt`. But which parts of DestinationPrompt are being used?
-  * Likely only scheduling_uuid and update_uuid in diff_determiner. Let's try narrowing down the interface.
-  * Hmm, narrowing down the interface also dramatically decreases debug- and testability, because it doesn't include the values used for generating the IDs. For now, I'll leave thsi be.
       
 * p2: infer scheduling_uuid during creation in the same way as during sync. Ensures they cannot drift.
 
@@ -119,3 +115,8 @@ is parsed to
 This seems to be a general problem with generics, but only when instantiating from markdown. 
 
 By beautifulsoup. So, this assumes that there is a lossless back-conversion, which does not seem to be the case. The alternative is to store the UUID with the prompt, which would've been a better choice! Huh! Perhaps this info is stored already in the UUID field. We still need changes in a few places; the syncer, and deleting based on note IDs. But that's very feasible!
+
+# Design decisions
+* Is there a need for "QAWithoutDoc"? It is because the 
+  * Seems it's being used inside `DestinationPrompt`. But which parts of DestinationPrompt are being used?
+  * Ah, so we cannot instantiate a full document from the data we get from Anki, and the document's tags is needed for the sync UUID. This means we need some other representation to get the sync UUID.


### PR DESCRIPTION
This PR experiments with using the raw markdown strings when adding to Anki. This would mean that Anki stores a plain, serialised "value object", so we are not sensitive to formatting changes which are not caught by the "cleaning" pipeline.

However, adding fields to existing Anki cards appears to be non-trivial. We have to:
* Modify the note-type, adding the new fields
* Update the cards, populating those new fields

So far, I've tried adding the new note type, and manually updating the cards to this new note type. In this case, the new fields are _not_ populated on next sync, and I don't know why. That is the current blocker.

## Example failure
The markdown 

'In Java, how do you go from `Optional<Optional<T>>` to `Optional<T>`?' 

is parsed to 

'In Java, how do you go from `Optional>` to `Optional`?'

This seems to be a general problem with generics, but only when instantiating from markdown. 

By beautifulsoup. So, this assumes that there is a lossless back-conversion, which does not seem to be the case. The alternative is to store the UUID with the prompt, which would've been a better choice! Huh! Perhaps this info is stored already in the UUID field. We still need changes in a few places; the syncer, and deleting based on note IDs. But that's very feasible!

## Theories

🔥 This might be because I had the note browser open. See https://github.com/FooSoft/anki-connect/issues/82
To test this, retry syncing without note browser open.

